### PR TITLE
feat: use blazediff instead of pixelmatch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "version": "0.0.5",
       "license": "Apache-2.0",
       "dependencies": {
+        "@blazediff/core": "^0.7.1",
         "@modelcontextprotocol/sdk": "^1.13.0",
         "@types/js-yaml": "^4.0.9",
         "fs-extra": "^11.1.1",
         "glob": "^11.0.3",
         "jimp": "^0.22.10",
         "js-yaml": "^4.1.0",
-        "pixelmatch": "^7.1.0",
         "pngjs": "^7.0.0",
         "sharp": "^0.34.2",
         "xml2js": "^0.6.2",
@@ -36,7 +36,6 @@
         "@types/fs-extra": "^11.0.4",
         "@types/mocha": "^10.0.6",
         "@types/node": "^20.10.5",
-        "@types/pixelmatch": "^5.2.6",
         "@types/pngjs": "^6.0.5",
         "@types/proxyquire": "^1.3.31",
         "@types/sinon": "^17.0.2",
@@ -364,6 +363,20 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@blazediff/core": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@blazediff/core/-/core-0.7.1.tgz",
+      "integrity": "sha512-/r+qHoNqlrDoY2/895ZxRVeU6MWVn2KyrdQEGcZTS0dgx1ouupHZTXAKEsNDpIUJVYdTeq7WQ3dIzmLev5QW+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@blazediff/types": "0.7.1"
+      }
+    },
+    "node_modules/@blazediff/types": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@blazediff/types/-/types-0.7.1.tgz",
+      "integrity": "sha512-bG9xy9SksbYjNG4LdhzSbp3M2V6XqxM9Ob/iW5xm+yaOLOc7B26w5QSrozh+cpVRsRz2G6BtF6x+Og5YZPStgw=="
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -2443,16 +2456,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
-      }
-    },
-    "node_modules/@types/pixelmatch": {
-      "version": "5.2.6",
-      "resolved": "https://registry.npmjs.org/@types/pixelmatch/-/pixelmatch-5.2.6.tgz",
-      "integrity": "sha512-wC83uexE5KGuUODn6zkm9gMzTwdY5L0chiK+VrKcDfEjzxh1uadlWTvOmAbCpnM9zx/Ww3f8uKlYQVnO/TrqVg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/pngjs": {
@@ -7721,18 +7724,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/pixelmatch": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-7.1.0.tgz",
-      "integrity": "sha512-1wrVzJ2STrpmONHKBy228LM1b84msXDUoAzVEl0R8Mz4Ce6EPr+IVtxm8+yvrqLYMHswREkjYFaMxnyGnaY3Ng==",
-      "license": "ISC",
-      "dependencies": {
-        "pngjs": "^7.0.0"
-      },
-      "bin": {
-        "pixelmatch": "bin/pixelmatch"
       }
     },
     "node_modules/pkce-challenge": {

--- a/package.json
+++ b/package.json
@@ -53,13 +53,13 @@
     "access": "public"
   },
   "dependencies": {
+    "@blazediff/core": "^0.7.1",
     "@modelcontextprotocol/sdk": "^1.13.0",
     "@types/js-yaml": "^4.0.9",
     "fs-extra": "^11.1.1",
     "glob": "^11.0.3",
     "jimp": "^0.22.10",
     "js-yaml": "^4.1.0",
-    "pixelmatch": "^7.1.0",
     "pngjs": "^7.0.0",
     "sharp": "^0.34.2",
     "xml2js": "^0.6.2",
@@ -77,7 +77,6 @@
     "@types/fs-extra": "^11.0.4",
     "@types/mocha": "^10.0.6",
     "@types/node": "^20.10.5",
-    "@types/pixelmatch": "^5.2.6",
     "@types/pngjs": "^6.0.5",
     "@types/proxyquire": "^1.3.31",
     "@types/sinon": "^17.0.2",

--- a/src/utils/screenshot-utils.ts
+++ b/src/utils/screenshot-utils.ts
@@ -7,10 +7,10 @@ import { readFileAsync, readdirAsync } from "./io";
 import { DEFAULT_FUZZY_MATCH_TOLERANCE_PERCENT } from "./constants";
 import { CryptoUtils } from "./crypto";
 
-// Add dynamic import function for pixelmatch
-async function getPixelmatch() {
-  const { default: pixelmatch } = await import("pixelmatch");
-  return pixelmatch;
+// Add dynamic import function for blazediff
+async function getBlazediff() {
+  const { default: blazediff } = await import("@blazediff/core");
+  return blazediff;
 }
 
 export interface ScreenshotComparisonResult {
@@ -231,7 +231,7 @@ export class ScreenshotUtils {
    * Compare two image buffers and return detailed comparison result
    * @param buffer1 First image buffer
    * @param buffer2 Second image buffer
-   * @param threshold Pixelmatch threshold (0-1, default 0.1)
+   * @param threshold BlazeDiff threshold (0-1, default 0.1)
    * @param fastMode Enable fast mode for bulk comparisons (lower quality but faster)
    * @returns Promise with comparison result
    */
@@ -283,8 +283,8 @@ export class ScreenshotUtils {
 
       // Perform pixel comparison with adjusted threshold for fast mode
       const adjustedThreshold = fastMode ? Math.min(threshold * 1.5, 0.2) : threshold;
-      const pixelmatch = await getPixelmatch();
-      const pixelDifference = pixelmatch(
+      const blazediff = await getBlazediff();
+      const pixelDifference = blazediff(
         img1.data,
         img2.data,
         undefined, // No diff output needed


### PR DESCRIPTION
# Description

Replace pixelmatch with [BlazeDiff](https://github.com/teimurjan/blazediff). BlazeDiff is 20-25% faster than pixelmatch, using the same API and producing the same results. It weighs twice as much, is actively supported, and is type-safe out of the box.

<img width="866" height="660" alt="Screenshot 2025-09-09 at 12 46 27" src="https://github.com/user-attachments/assets/dda023af-bacc-49b2-ad9e-f8b33924d02c" />

- It's already been checked and integrated into [vega/vega](https://github.com/vega/vega/pull/4125).
- It's already been approved and scheduled for integration into [antvis/g](https://github.com/antvis/G/pull/2023)
