### PR TITLE
Update doc for mavenLocal publishing

### DIFF
--- a/docs/features/test-execution/junitrunner.md
+++ b/docs/features/test-execution/junitrunner.md
@@ -8,4 +8,13 @@ matches the UI being tested.
 testImplementation("com.zillow.automobile.junitrunner:x.y.z")
 ```
 
-Note that this artifact hasn't been published to Maven Central just yet and is forthcoming.
+Note that this artifact hasn't been published to Maven Central just yet and is forthcoming.  
+
+
+In the meantime, publish to your mavenLocal (`~/.m2`) via:
+
+```
+./gradlew publishToMavenLocal
+```
+
+and use the above testImplementation dependency with `x.y.z` version from `android/junit-runner/build.gradle.kts`.


### PR DESCRIPTION
Update `docs/features/test-execution/junitrunner.md` to inform the end-user how to publish the artifact locally for use in automatic test authoring mode.